### PR TITLE
Fix undeclared dependency on mongodb module

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -1,12 +1,11 @@
 import DataLoader from 'dataloader'
-import { ObjectId } from 'mongodb'
-import { EJSON } from 'bson'
+import { EJSON, ObjectId } from 'bson'
 
-import { getCollection } from './helpers'
+import { getCollection, isObjectId } from './helpers'
 
-export const idToString = id => (id instanceof ObjectId ? id.toHexString() : id)
+export const idToString = id => (isObjectId(id) ? id.toHexString() : id)
 const stringToId = str => {
-  if (str instanceof ObjectId) {
+  if (isObjectId(str)) {
     return str
   }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,3 +1,5 @@
+import { ObjectId } from 'bson'
+
 const TYPEOF_COLLECTION = 'object'
 
 export const isModel = x => Boolean(x && x.name === 'model')
@@ -6,3 +8,31 @@ export const isCollectionOrModel = x =>
   Boolean(x && (typeof x === TYPEOF_COLLECTION || isModel(x)))
 
 export const getCollection = x => (isModel(x) ? x.collection : x)
+
+export const isObjectId = id => {
+  // Extracted from:
+  // https://github.com/mongodb/js-bson/blob/master/src/objectid.ts#L312
+  if (id instanceof ObjectId) {
+    return true
+  }
+
+  // Duck-Typing detection of ObjectId like objects
+  if (
+    typeof id === 'object' &&
+    'toHexString' in id &&
+    typeof id.toHexString === 'function'
+  ) {
+    if (typeof id.id === 'string') {
+      return id.id.length === 12
+    }
+    return (
+      id.toHexString().length === 24 &&
+      checkForHexRegExp.test(id.id.toString('hex'))
+    )
+  }
+
+  return false
+}
+
+// Regular expression that checks for hex value
+const checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');


### PR DESCRIPTION
The mongodb module is imported from src/cache.js but isn't listed as a dependeny in package.json.

Instead of hauling in the mongodb module just for its ObjectId implementation, use ObjectId from the bson module, which is already a dependency.

This requires an implementation of isObjectId(any) => boolean (with duck typing) to use instead of instanceof ObjectId, as ObjectId instances from the bson module won't match instances from other modules. isObjectId() is added to src/helpers.js.